### PR TITLE
Enlarge board ratio

### DIFF
--- a/src/components/Board/Board.tsx
+++ b/src/components/Board/Board.tsx
@@ -37,7 +37,7 @@ function Board({
   return (
     <div
       className={clsx(
-        'relative w-full min-w-[266px] p-8 border-4 border-zinc-300 dark:border-zinc-700 rounded-2xl shadow-xl transition-all duration-500',
+        'relative w-full min-w-[360px] p-8 border-4 border-zinc-300 dark:border-zinc-700 rounded-2xl shadow-xl transition-all duration-500',
         'box-border aspect-ratio-1',
         'bg-gradient-to-br from-zinc-50 to-zinc-200 dark:from-zinc-900 dark:to-zinc-800',
         phase === 'playing' || phase === 'placing'

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -268,7 +268,7 @@ export default function Game({
           </GameButton>
         )}
       </div>
-      <div className="board-container flex flex-col aspect-ratio-1 items-center w-[min(800px,100dvh-280px)] max-w-[calc(100dvw-32px)] transition-all">
+      <div className="board-container flex flex-col aspect-ratio-1 items-center w-[min(900px,100dvh-240px)] max-w-[calc(100dvw-32px)] transition-all">
         <Board
           board={board}
           phase={phase}


### PR DESCRIPTION
## Summary
- enlarge the min width of the board element
- allow the board container to grow up to 900px (was 800px)

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68429c76049c83328ff04d0b58feb5ef